### PR TITLE
Opentracing Support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/graphql-go/graphql v0.7.8
+	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/graphql-go/graphql v0.7.8 h1:769CR/2JNAhLG9+aa8pfLkKdR0H+r5lsQqling5WwpU=
 github.com/graphql-go/graphql v0.7.8/go.mod h1:k6yrAYQaSP59DC5UVxbgxESlmVyojThKdORUqGDGmrI=
+github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
+github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/trace.go
+++ b/trace.go
@@ -1,0 +1,43 @@
+package resly
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+	"github.com/opentracing/opentracing-go/log"
+)
+
+func DefineTracingFunc(tracer opentracing.Tracer) ClosureDef {
+	return func(funcdef FuncDef, in []reflect.Value) []reflect.Value {
+		var (
+			ctx context.Context = context.Background()
+		)
+
+		if len(in) > 1 {
+			// Retrieve the context from the list of arguments.
+			if funcCtx, ok := in[0].Interface().(context.Context); ok {
+				ctx = funcCtx
+			}
+		}
+
+		span, ctx := opentracing.StartSpanFromContextWithTracer(ctx, tracer, funcdef.Name)
+		defer span.Finish()
+
+		res, err := funcdef.call(in)
+
+		if err != nil {
+			ext.Error.Set(span, true)
+			span.LogFields(
+				log.String("event", "error"),
+				log.String("message", err.Error()),
+			)
+		}
+
+		return []reflect.Value{
+			reflect.ValueOf(res),
+			reflect.ValueOf(err),
+		}
+	}
+}


### PR DESCRIPTION
This patch adds support of opentracing for queries, mutations and type methods.

closes #15 