### PR TITLE
Tracing context from the HTTP headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,37 @@ go get github.com/resly/resly
 The [Resly Documentation](https://resly.github.io/resly) contains additional
 details on how to get started with GraphQL and Resly.
 
+## Usage
+
+Implementation of the Resly, comparing to other Go frameworks does not require
+GraphQL schema declaration. Instead, it is highly anticipated to work with
+business models of the service as API entities for GraphQL server.
+
+### Simple query
+```go
+import "context"
+import "net/http"
+
+import "github.com/resly/resly"
+
+
+func main() {
+    // Define a query function to retrieve "names".
+    queryNames := func(ctx context.Context) ([]string, error) {
+        return []string{"Steve", "Wozniak"}, nil
+    }
+
+    // Create Resly server with a single GraphQL query.
+    s := resly.Server {
+        Queries: []resly.FuncDef{resly.NewFunc("names", queryNames)},
+    }
+
+    // Serve GraphQL service at "localhost:8000/graphql" endpoint.
+    http.Handle("/graphql", s)
+    http.ListenAndServe(":8000", nil)
+}
+```
+
 ## License
 
 Resly is [MIT licensed](LICENSE).

--- a/server.go
+++ b/server.go
@@ -247,6 +247,9 @@ func (s *Server) createHandler() http.Handler {
 	if s.RequestTimeout != 0 {
 		handler = http.TimeoutHandler(handler, s.RequestTimeout, ErrRequestTimeout.Error())
 	}
+	if s.Tracer != nil {
+		handler = TracingHandler(handler, s.Tracer)
+	}
 	return handler
 }
 


### PR DESCRIPTION
This patch de-serializes opentracing context from HTTP headers and
wraps each GraphQL call as RPC call, when tracing is enabled.