### PR TITLE
Lower first letter in query args

### DIFF
--- a/json.go
+++ b/json.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"reflect"
 	"strings"
+	"unicode"
 )
 
 func jsonName(sf reflect.StructField) (name string, ignore bool) {
@@ -11,9 +12,11 @@ func jsonName(sf reflect.StructField) (name string, ignore bool) {
 	values := strings.Split(tag, ",")
 
 	// When the JSON tag is not defined, or name is not defined explicitely,
-	// use field name without any modifications at all.
+	// use field name lowering the first letter.
 	if !ok || len(values) == 0 || values[0] == "" {
-		return sf.Name, false
+		name := []rune(sf.Name)
+		name[0] = unicode.ToLower(name[0])
+		return string(name), false
 	}
 
 	if values[0] == "-" && len(values) == 1 {

--- a/schema.go
+++ b/schema.go
@@ -189,6 +189,9 @@ func newMutationFunc(funcdef FuncDef) graphql.FieldResolveFn {
 }
 
 // newQueryArgs creates configuration of the arguments for the query function.
+//
+// All fields of the specified gotype will be represented in a camel case for the
+// sake of uniformity with GraphQL style notation.
 func newQueryArgs(gotype reflect.Type, types map[string]graphql.Type) (
 	graphql.FieldConfigArgument, error,
 ) {
@@ -196,6 +199,12 @@ func newQueryArgs(gotype reflect.Type, types map[string]graphql.Type) (
 		return nil, nil
 	}
 
+	// Specify a fake object name to comply with graphql requirements on input
+	// object naming. In fact, there is no need to create an InputObject type,
+	// as the fields will be passed to tha FieldConfig detached from object.
+	//
+	// This process is required to populate the "types" mapping, in order to
+	// register all nested types.
 	gqltype, err := newObject("@", gotype, inObjectType, types)
 	if err != nil {
 		return nil, err

--- a/schema_test.go
+++ b/schema_test.go
@@ -42,11 +42,12 @@ func TestNewQueryArgs_OK(t *testing.T) {
 		gotype interface{}
 		want   QueryArgs
 	}{
-		{struct{ Name string }{}, QueryArgs{"Name": graphql.NewNonNull(graphql.String)}},
+		{struct{ Name string }{}, QueryArgs{"name": graphql.NewNonNull(graphql.String)}},
 		{struct {
 			Key   int
 			Value *uint64
-		}{}, QueryArgs{"Key": graphql.NewNonNull(graphql.Int), "Value": graphql.Int}},
+		}{}, QueryArgs{"key": graphql.NewNonNull(graphql.Int), "value": graphql.Int}},
+		{struct{ UserName *string }{}, QueryArgs{"userName": graphql.String}},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This patch automatically performs lower-casing of ther first letter of
a query argument name.